### PR TITLE
make sure pages uploads not readme

### DIFF
--- a/src/build.js
+++ b/src/build.js
@@ -156,6 +156,8 @@ function build() {
     fs.writeFileSync(path.join(DIST, 'posts', `${post.slug}.html`), postHtml);
   }
 
+  fs.writeFileSync(path.join(DIST, '.nojekyll'), '');
+
   console.log(`Built ${1 + posts.length} page(s) → dist/`);
   if (posts.length) {
     posts.forEach(p => console.log(`  posts/${p.slug}.html`));


### PR DESCRIPTION
## What does this PR do?

## Related issue

Closes #

## Checklist

- [ ] `npm test` all tests pass
- [ ] `npm run build` runs without errors
- [ ] Output in `dist/` looks correct
- [ ] If adding an icon, the README supported icons list is updated
- [ ] If changing config fields, the README usage section is updated
