### PR TITLE
Styling overhaul

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,19 +20,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `build.js` helper functions (`slugify`, `formatDate`, `extractPreview`, `fontVars`) are now exported for testing
 - `build.js` build execution is now guarded with `require.main === module` so importing the file doesn't trigger a build
 
-## [0.1.0] - 2026-03-19
+## [0.4.0] - 2026-04-07
 
 ### Added
 
-- Initial build script, reads `homestead.yaml` and outputs static HTML to `dist/`
-- Handlebars templates for the main page and individual post pages
-- Markdown blog post support with YAML frontmatter (`title`, `date`, `excerpt`)
-- Post preview cards on the index page with excerpt and date
-- Theme customization via config: background, surface, accent, text, font, radius, border
-- Google Fonts integration: load any font by name or fall back to system stack
-- Bundled inline SVG icons: github, twitter, instagram, linkedin, youtube, twitch, discord, bluesky, email, globe, rss
-- Avatar support: copies image to `dist/` for self-contained output
-
+- `max_posts` option on blog and portfolio sections — limits how many posts appear on the index page, full post pages are still built for all posts
+- `show_preview` option on blog sections — set to `false` to hide the excerpt snippet on cards, defaults to `true`
+- Text labels in links sections — add `- text: "Label"` anywhere in a links list to group and separate buttons with a small heading
+- Portfolio posts now open in a modal overlay instead of navigating to a separate page — close with the X button, clicking outside, or Escape
 
 ## [0.2.0] - 2026-03-26
 
@@ -48,3 +43,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Created modular rows you can add any number of sections to as you want
 - Each row has a width modifier, and the sections in them can be a custom share of the width
     - Small + one links section is like the LinkTree setup
+
+## [0.1.0] - 2026-03-19
+
+### Added
+
+- Initial build script, reads `homestead.yaml` and outputs static HTML to `dist/`
+- Handlebars templates for the main page and individual post pages
+- Markdown blog post support with YAML frontmatter (`title`, `date`, `excerpt`)
+- Post preview cards on the index page with excerpt and date
+- Theme customization via config: background, surface, accent, text, font, radius, border
+- Google Fonts integration: load any font by name or fall back to system stack
+- Bundled inline SVG icons: github, twitter, instagram, linkedin, youtube, twitch, discord, bluesky, email, globe, rss
+- Avatar support: copies image to `dist/` for self-contained output

--- a/README.md
+++ b/README.md
@@ -64,10 +64,9 @@ Your home base on the web. Compile your links, create posts to show off projects
 
 **Why Homestead?**
 
-- No third-party platform or account needed (outside Github)
+- No third-party platform or account needed (outside GitHub)
 - Create your own site without opening a code editor
-- Zero JavaScript output, plain HTML and CSS for simplicity
-- Blog support built in, just drop Markdown files in a folder
+- Blog and portfolio support built in, just drop Markdown files in a folder
 - Fully themeable from one config file
 - Free to host on GitHub Pages
 
@@ -116,57 +115,82 @@ Your home base on the web. Compile your links, create posts to show off projects
 
 All configuration lives in `homestead.yaml` at the project root.
 
+### Theme
+
 ```yaml
-# Your display name — shown as the page title and <h1>
 title: "Jane Doe"
-
-# Short bio shown below your name (optional)
 bio: "Designer & maker of things."
-
-# Path to your profile picture, relative to this file (optional)
-# avatar: ".images/avatar.png"
+avatar: "./images/avatar.png"  # optional
 
 theme:
-  background: "#f6f1e8" # page background
-  surface: "#fffaf2" # card and button background
-  accent: "#c26d3a" # hover and highlight color
-  text: "#2f241f" # body text color
-  font: "Oxygen" # Google Font name, or "system" for no CDN
-  radius: "16px" # button corner radius
-  border: "#d4b99a" # optional border/shadow color (omit to disable)
-
-links:
-  - label: "GitHub"
-    url: "https://github.com/janedoe"
-    icon: github
-  - label: "Twitter / X"
-    url: "https://x.com/janedoe"
-    icon: twitter
-  - label: "My Website"
-    url: "https://janedoe.com"
-    icon: globe
-
-# Folder of Markdown files to render as blog posts (optional — omit to hide)
-posts_dir: "./posts"
+  background: "#f6f1e8"  # page background
+  surface: "#fffaf2"     # card and button background
+  accent: "#c26d3a"      # hover and highlight color
+  text: "#2f241f"        # body text color
+  font: "Oxygen"         # any Google Font name, or "system" for no CDN
+  radius: "16px"         # corner radius on cards and buttons
+  border: "#d4b99a"      # optional border color (omit to disable)
 ```
+
+### Layout
+
+The page is built from rows stacked top to bottom. Each row holds one or more sections displayed side by side. Sections in the same row split its width equally by default, or you can weight them with `width`.
+
+```yaml
+rows:
+  - column_width: small   # xsmall | small | medium | large (default)
+    sections:
+      - id: "connect"
+        type: "links"
+        width: 1
+        links:
+          - text: "Social"
+          - label: "GitHub"
+            url: "https://github.com/janedoe"
+            icon: github
+          - label: "Twitter / X"
+            url: "https://x.com/janedoe"
+            icon: twitter
+
+  - column_width: medium
+    sections:
+      - id: "projects"
+        type: "portfolio"
+        title: "Projects"
+        posts_dir: "./posts/projects"
+        max_posts: 6        # optional — limits cards shown on index
+
+      - id: "blog"
+        type: "blog"
+        title: "Writing"
+        posts_dir: "./posts/writing"
+        max_posts: 5        # optional
+        show_preview: true  # set to false to hide excerpt snippets
+```
+
+**Section types:**
+- `links` — a column of link buttons. Add `- text: "Label"` anywhere in the list to insert a small group heading.
+- `blog` — post cards with title, date, and a preview snippet. Clicking opens the full post page.
+- `portfolio` — compact post cards in a two-column grid. Clicking opens the post in a modal overlay without leaving the page.
 
 **Supported icons:** `github`, `twitter`, `instagram`, `linkedin`, `youtube`, `twitch`, `discord`, `bluesky`, `email`, `globe`, `rss`
 
 ### Writing Posts
 
-Drop `.md` files into your `posts/` folder with a frontmatter block:
+Drop `.md` files into any `posts_dir` folder with a frontmatter block:
 
 ```markdown
 ---
 title: "My First Post"
 date: 2026-03-01
-excerpt: "A short summary shown on the index page."
+subtitle: "A short line shown under the title on cards."
 ---
 
 Your post content here, written in standard Markdown.
+The first paragraph is automatically used as the preview snippet on blog cards.
 ```
 
-Each post gets its own page at `dist/posts/<slug>.html` after a build.
+Blog posts get their own page at `dist/<section-id>/<slug>.html`. Portfolio posts open in a modal on the index page.
 
 ### Deploying to GitHub Pages
 
@@ -182,7 +206,7 @@ Each post gets its own page at `dist/posts/<slug>.html` after a build.
 
 - [ ] More built-in icons
 - [ ] Multiple bundled themes to pick from
-- [ ] Image and GIF support in posts
+- [ ] Profile layout options (sidebar, centered)
 - [ ] "Use this template" GitHub template repo setup
 - [ ] Auto-deploy via GitHub Actions on push
 - [ ] Full from-zero video tutorial

--- a/homestead.yaml
+++ b/homestead.yaml
@@ -43,6 +43,8 @@ rows:
         type: "links"
         width: 3
         links:
+          - text: "Social"
+
           - label: "GitHub"
             url: "https://github.com/yourname"
             icon: github
@@ -51,13 +53,15 @@ rows:
             url: "https://x.com/yourname"
             icon: twitter
 
-          - label: "My Website"
-            url: "https://yoursite.com"
-            icon: globe
-
           - label: "LinkedIn"
             url: "https://linkedin.com/in/yourname"
             icon: linkedin
+
+          - text: "Contact"
+
+          - label: "My Website"
+            url: "https://yoursite.com"
+            icon: globe
 
           - label: "Email"
             url: "mailto:you@example.com"

--- a/homestead.yaml
+++ b/homestead.yaml
@@ -68,6 +68,7 @@ rows:
         title: "Portfolio"
         width: 5
         posts_dir: "./posts/projects"
+        max_posts: 6   # limit how many show on the index (optional)
 
   - column_width: medium
     sections:
@@ -75,3 +76,5 @@ rows:
         type: "blog"
         title: "Blog"
         posts_dir: "./posts/writing"
+        max_posts: 10        # limit how many show on the index (optional)
+        show_preview: true  # set to false to hide the preview snippet on cards (optional, default true)

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "homestead",
-  "version": "0.1.0",
+  "version": "0.4.0",
   "main": "index.js",
   "scripts": {
     "build": "node src/build.js",

--- a/src/build.js
+++ b/src/build.js
@@ -165,6 +165,7 @@ function build() {
       const { cardPosts } = sectionPostMap.get(section.id);
       const links = section.links.map(link => ({
         ...link,
+        isText: !link.url,
         iconSvg: link.icon ? (icons[link.icon] || null) : null,
       }));
       return {

--- a/src/build.js
+++ b/src/build.js
@@ -147,9 +147,13 @@ function build() {
       ? loadPostsFromDir(section.posts_dir, section.id)
       : [];
 
-    const cardPosts = section.type === 'portfolio'
+    let cardPosts = section.type === 'portfolio'
       ? allPosts.map(p => ({ ...p, preview: null, date: null }))
-      : allPosts;
+      : allPosts.map(p => ({ ...p, preview: section.show_preview ? p.preview : null }));
+
+    if (section.max_posts != null) {
+      cardPosts = cardPosts.slice(0, section.max_posts);
+    }
 
     sectionPostMap.set(section.id, { allPosts, cardPosts });
   }

--- a/src/config.js
+++ b/src/config.js
@@ -76,6 +76,8 @@ function loadConfig(root = process.cwd()) {
         links: s.links || [],
         posts_dir: s.posts_dir || null,
         width: s.width != null ? s.width : 1,
+        max_posts: s.max_posts != null ? s.max_posts : null,
+        show_preview: s.show_preview !== false,
       })),
     })),
   };

--- a/src/styles/base.css
+++ b/src/styles/base.css
@@ -119,6 +119,15 @@ h1 {
   gap: 0.5rem;
 }
 
+.link-label {
+  font-size: 0.7rem;
+  font-weight: 600;
+  letter-spacing: 0.1em;
+  text-transform: uppercase;
+  opacity: 0.4;
+  padding: 0.5rem 0 0.125rem;
+}
+
 .link-btn {
   display: flex;
   align-items: center;
@@ -160,9 +169,6 @@ h1 {
 }
 
 /* --- Posts --- */
-
-.posts {
-}
 
 /* In portfolio sections the grid is tighter, so reduce card padding */
 .site-section--portfolio .post-card {

--- a/src/styles/base.css
+++ b/src/styles/base.css
@@ -176,6 +176,15 @@ h1 {
   margin-bottom: 0;
 }
 
+/* button.post-card resets browser defaults so portfolio cards look the same as blog link cards */
+button.post-card {
+  width: 100%;
+  font-family: inherit;
+  font-size: inherit;
+  text-align: left;
+  cursor: pointer;
+}
+
 .post-card {
   display: block;
   padding: 0.875rem 1rem;
@@ -341,4 +350,71 @@ article {
   max-width: 100%;
   border-radius: var(--radius);
   margin: 1rem 0;
+}
+
+/* --- Modal --- */
+
+.modal-overlay {
+  position: fixed;
+  inset: 0;
+  background: rgba(0, 0, 0, 0.55);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  z-index: 100;
+  padding: 2rem;
+}
+
+.modal-overlay[hidden] {
+  display: none;
+}
+
+.modal {
+  background: var(--surface);
+  border-radius: var(--radius);
+  border: 1px solid var(--border, transparent);
+  max-width: 680px;
+  width: 100%;
+  max-height: 85vh;
+  overflow-y: auto;
+  padding: 2.5rem;
+  position: relative;
+}
+
+.modal-close {
+  position: absolute;
+  top: 1rem;
+  right: 1rem;
+  background: none;
+  border: none;
+  color: var(--text);
+  font-size: 1.5rem;
+  line-height: 1;
+  cursor: pointer;
+  opacity: 0.4;
+  padding: 0.25rem 0.5rem;
+  font-family: inherit;
+}
+
+.modal-close:hover {
+  opacity: 1;
+}
+
+.modal-post-title {
+  font-size: 1.4rem;
+  font-weight: 700;
+  letter-spacing: -0.02em;
+  margin-bottom: 0.375rem;
+}
+
+@media (max-width: 640px) {
+  .modal-overlay {
+    padding: 1rem;
+    align-items: flex-end;
+  }
+
+  .modal {
+    max-height: 90vh;
+    border-radius: var(--radius) var(--radius) 0 0;
+  }
 }

--- a/src/templates/index.html.hbs
+++ b/src/templates/index.html.hbs
@@ -45,5 +45,43 @@
     </div>
     {{/each}}
   </main>
+
+  <div class="modal-overlay" id="hs-modal" hidden>
+    <div class="modal" role="dialog" aria-modal="true">
+      <button class="modal-close" id="hs-modal-close" aria-label="Close">&times;</button>
+      <div class="modal-body" id="hs-modal-body"></div>
+    </div>
+  </div>
+
+  <script>
+    (function () {
+      var overlay = document.getElementById('hs-modal');
+      var body = document.getElementById('hs-modal-body');
+      var closeBtn = document.getElementById('hs-modal-close');
+
+      document.querySelectorAll('[data-modal-target]').forEach(function (btn) {
+        btn.addEventListener('click', function () {
+          var src = document.getElementById(btn.dataset.modalTarget);
+          body.innerHTML = src.innerHTML;
+          overlay.removeAttribute('hidden');
+          document.body.style.overflow = 'hidden';
+        });
+      });
+
+      function closeModal() {
+        overlay.setAttribute('hidden', '');
+        body.innerHTML = '';
+        document.body.style.overflow = '';
+      }
+
+      closeBtn.addEventListener('click', closeModal);
+      overlay.addEventListener('click', function (e) {
+        if (e.target === overlay) closeModal();
+      });
+      document.addEventListener('keydown', function (e) {
+        if (e.key === 'Escape' && !overlay.hasAttribute('hidden')) closeModal();
+      });
+    })();
+  </script>
 </body>
 </html>

--- a/src/templates/sections/links.hbs
+++ b/src/templates/sections/links.hbs
@@ -1,10 +1,14 @@
 <nav class="links">
   {{#each links}}
+  {{#if isText}}
+  <p class="link-label">{{text}}</p>
+  {{else}}
   <a class="link-btn" href="{{ url }}" target="_blank" rel="noopener noreferrer">
     {{#if iconSvg}}
     <span class="icon">{{{ iconSvg }}}</span>
     {{/if}}
     {{ label }}
   </a>
+  {{/if}}
   {{/each}}
 </nav>

--- a/src/templates/sections/portfolio.hbs
+++ b/src/templates/sections/portfolio.hbs
@@ -1,12 +1,17 @@
 {{#if posts.length}}
 <div class="posts">
   {{#each posts}}
-  <a class="post-card" href="{{ url }}">
+  <button class="post-card" data-modal-target="post-{{../id}}-{{slug}}">
     <div class="post-header">
       <span class="post-title">{{ title }}</span>
     </div>
     {{#if subtitle}}<p class="post-subtitle">{{ subtitle }}</p>{{/if}}
-  </a>
+  </button>
+  <div id="post-{{../id}}-{{slug}}" hidden>
+    <h2 class="modal-post-title">{{title}}</h2>
+    {{#if date}}<p class="post-meta">{{date}}</p>{{/if}}
+    <div class="content">{{{ content }}}</div>
+  </div>
   {{/each}}
 </div>
 {{/if}}


### PR DESCRIPTION
## What does this PR do?
- Changes portfolio items to show in a modal when clicked
- Text you can add into the links section to label and separate

## Related issue

Closes #

## Checklist

- [x] `npm test` all tests pass
- [x] `npm run build` runs without errors
- [x] Output in `dist/` looks correct
- [x] If adding an icon, the README supported icons list is updated
- [x] If changing config fields, the README usage section is updated
